### PR TITLE
Using lowercase Emma to support case-sensitive fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bundle exec rake run_tests
 
 Add this line to your application's Gemfile:
 
-    gem 'Emma'
+    gem 'emma'
 
 And then execute:
 
@@ -28,13 +28,13 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install Emma
+    $ gem install emma
 
 ## Usage
 
 ## Instantiation
 ```ruby
-require 'Emma'
+require 'emma'
 em = Emma::Setup.new 'account_id', 'public_key', 'private_key', 'debug_true_or_false'
 ```
 

--- a/lib/emma.rb
+++ b/lib/emma.rb
@@ -1,6 +1,6 @@
-require "Emma/version"
-require "Emma/client"
-require "Emma/configurable"
+require "emma/version"
+require "emma/client"
+require "emma/configurable"
 
 module Emma
   class << self

--- a/lib/emma/client.rb
+++ b/lib/emma/client.rb
@@ -1,14 +1,14 @@
 require 'json'
 require 'httparty'
-require 'Emma/configurable'
-require 'Emma/api/members'
-require 'Emma/api/fields'
-require 'Emma/api/groups'
-require 'Emma/api/mailings'
-require 'Emma/api/response'
-require 'Emma/api/searches'
-require 'Emma/api/triggers'
-require 'Emma/api/webhooks'
+require 'emma/configurable'
+require 'emma/api/members'
+require 'emma/api/fields'
+require 'emma/api/groups'
+require 'emma/api/mailings'
+require 'emma/api/response'
+require 'emma/api/searches'
+require 'emma/api/triggers'
+require 'emma/api/webhooks'
 
 
 module Emma


### PR DESCRIPTION
It appears this gem hasn't been tested on case-sensitive file systems like Linux.

Mac OS X's default file system is case-insensitive meaning `require "Emma"` would work.

Since most production systems run on case-sensitive file systems, I have modified the gem to work with both.
