### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bundle exec rake run_tests
 
 Add this line to your application's Gemfile:
 
-    gem 'emma'
+    gem 'emma', :github => "myemma/EmmaRuby"
 
 And then execute:
 


### PR DESCRIPTION
Updating the read me to show the correct way to install the emma gem.  Otherwise it installs `http://github.com/jarib/emma-rb` which can cause some headaches when trying to get this gem into development.
