### PR TITLE
Update dependencies with security vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 ---
 language: ruby
 rvm:
-- 1.9.2
-- 1.9.3
+- 2.3.3
 script:
 - bundle exec rake run_tests
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development, :test do
+  gem 'test-unit'
+  gem 'minitest'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.11)
-      i18n (~> 0.6)
-      multi_json (~> 1.0)
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.3.2)
+    concurrent-ruby (1.0.5)
     crack (0.3.2)
     httparty (0.10.0)
       multi_json (~> 1.0)
       multi_xml
-    i18n (0.6.1)
-    json (1.7.6)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    json (1.8.3)
+    minitest (5.11.3)
     multi_json (1.5.0)
     multi_xml (0.5.2)
+    power_assert (1.1.1)
     rake (10.0.3)
     shoulda (3.3.2)
       shoulda-context (~> 1.0.1)
@@ -27,6 +33,11 @@ GEM
     shoulda-context (1.0.2)
     shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
+    test-unit (3.2.7)
+      power_assert
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     vcr (2.4.0)
     webmock (1.9.0)
       addressable (>= 2.2.7)
@@ -37,7 +48,12 @@ PLATFORMS
 
 DEPENDENCIES
   emma!
+  minitest
   rake
   shoulda
+  test-unit
   vcr
   webmock
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
This updates the dependencies with known security vulnerabilities.

After updating the deps, I was still able to successfully run the tests with `bundle exec rake run_tests`.